### PR TITLE
Move to Julia 1.1 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ defaults: &defaults
         name: Install Julia v0.6.4
         command: |
           curl -o julia.tar.gz --location --silent --show-error \
-            https://julialang-s3.julialang.org/bin/linux/x64/0.6/julia-0.6.4-linux-x86_64.tar.gz && \
+            https://julialang-s3.julialang.org/bin/linux/x64/1.1/julia-1.1.0-linux-x86_64.tar.gz && \
           mkdir julia && \
           tar --extract --gzip --strip 1 --directory=julia --file=julia.tar.gz && \
           echo 'export PATH="/tmp/project/julia/bin:$PATH"' >> $BASH_ENV
@@ -22,10 +22,13 @@ defaults: &defaults
     - run:
         name: Install Lint.jl
         # Note the "using Lint" is to pre-compile the cache
-        command: julia -E 'Pkg.add("Lint"); using Lint;'
+        # Also, we are using the `master` branch directly since a working
+        # version isn't currently released.
+        command: |
+          julia -E 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/tonyhffong/Lint.jl", rev="master")); using Lint;'
     - run:
         name: Lint.jl version
-        command: julia -E 'Pkg.installed("Lint")'
+        command: julia -E 'using Pkg; Pkg.status("Lint");'
     - run:
         name: Create VFB for Atom to run in
         command: /usr/local/bin/xvfb_start

--- a/lib/julia-server.jl
+++ b/lib/julia-server.jl
@@ -1,30 +1,34 @@
-using Lint
+using Pkg;
+
+LintPkg = PackageSpec(url="https://github.com/tonyhffong/Lint.jl", rev="master");
 
 named_pipe = ARGS[1]
 
-if Pkg.installed("Lint") == nothing
-    print(STDERR, "linter-julia-installing-lint")
+if get(Pkg.installed(), "Lint", nothing) == nothing == nothing
+    print(Base.stderr, "linter-julia-installing-lint");
     try
-        Pkg.add("Lint")
+        Pkg.add(LintPkg);
     catch
-        print(STDERR, "linter-julia-msg-install")
-        rethrow()
+        print(Base.stderr, "linter-julia-msg-install");
+        rethrow();
     end
 else
-    if Pkg.installed("Lint") < v"0.3.0"
-        print(STDERR, "linter-julia-updating-lint")
+    if get(Pkg.installed(), "Lint", nothing) < v"0.3.0"
+        print(Base.stderr, "linter-julia-updating-lint");
         try
-            Pkg.update("Lint")
+            # NOTE: This doesn't appear to be working?
+            Pkg.update(LintPkg);
         catch
-            print(STDERR, "linter-julia-msg-update")
-            rethrow()
+            print(Base.stderr, "linter-julia-msg-update");
+            rethrow();
         end
     else # start the server
         try
-            lintserver(named_pipe,"standard-linter-v2")
+            using Lint;
+            lintserver(named_pipe,"standard-linter-v2");
         catch
-            print(STDERR, "linter-julia-msg-load")
-            rethrow()
+            print(Base.stderr, "linter-julia-msg-load");
+            rethrow();
         end
     end
 end

--- a/spec/linter-julia-spec.js
+++ b/spec/linter-julia-spec.js
@@ -30,7 +30,7 @@ describe('The Julia Lint.jl provider for Linter', () => {
     expect(messages[0].excerpt).toBe(excerpt);
     expect(messages[0].location.file).toBe(badFile);
     // NOTE: This is invalid! Bug in Lint.jl
-    expect(messages[0].location.position).toEqual([[1, 0], [1, 80]]);
+    expect(messages[0].location.position).toEqual([[23, 0], [23, 80]]);
   });
 
   it('finds nothing wrong with a valid file', async () => {


### PR DESCRIPTION
BREAKING CHANGE: Drop support for Julia v0.6.

Moves the codebase to supporting Julia v1.1 (and up?). This requires updating how Lint.jl is installed in CI and the server to a method that is incompatible with the older versions. Currently since Lint.jl hasn't been updated in the Julia registry we need to install it from their `master` branch.

Also note that the specs have been changed since it seems that Lint.jl now reports a different line number for the error in question... that is even further off from what it should be.

As I know essentially nothing about Julia it would be great if somebody more familiar with it could review this and give it a sanity check. @TeroFrondelius? @TotalVerb?